### PR TITLE
I recently started encrypting my SSH private keys. This commit makes OneWay load passwords from the keychain even if public-key authentication is enabled. This password will then be used to decrypt the private key.

### DIFF
--- a/control/Controller.m
+++ b/control/Controller.m
@@ -281,7 +281,7 @@
 	
 	id <CurlClient>client = [self uploadClientForType:[location type]];
 	
-	if (([location password] == nil || [[location password] isEqualToString:@""]) && ![location usePublicKeyAuth])
+	if (([location password] == nil || [[location password] isEqualToString:@""]))
 	{
 		[location setPassword:[self getPasswordFromKeychain:[location hostname] 
 												   username:[location username] 
@@ -323,7 +323,7 @@
 {	
 	[self showTransfersView:nil];
 	
-	if ((![record password] || [[record password] isEqualToString:@""]) && ![record usePublicKeyAuth])
+	if ((![record password] || [[record password] isEqualToString:@""]))
 	{
 		[record setPassword:[self getPasswordFromKeychain:[record hostname] 
 												 username:[record username] 


### PR DESCRIPTION
Controller.m: Also request the internet password from the keychain if private-key authentication is enabled (the private key may be encrypted with the password stored in the keychain).
